### PR TITLE
fix Eigen target name when using Conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,12 @@ else()
 endif()
 
 find_package(Eigen3 REQUIRED NO_MODULE)
-target_link_libraries(epigraph Eigen3::Eigen)
+if(TARGET Eigen3::Eigen)
+    target_link_libraries(epigraph Eigen3::Eigen)
+else()
+    # Conan uses the package name for the target name
+    target_link_libraries(epigraph Eigen3::Eigen3)
+endif()
 
 # ==== Testing ====
 find_package(Catch2)


### PR DESCRIPTION
I found an issue that went unnoticed because Eigen was installed on the systems where I tested the package...

Conan creates CMake targets using the `PackageName::PackageName` format which doesn't work for Eigen since the target name is `Eigen3::Eigen`

I couldn't find a way to solve the issue without making modifications to Epigraph.

The solution here is to create a "fake" target `Eigen3::Eigen` that publicly links to `Eigen3::Eigen3` in the case Conan is used. 

Conan is detected if the `find_package` succeeds but the `Eigen3::Eigen` target doesn't exist, that way no user intervention is required and it shouldn't change anything if system dependencies are used.